### PR TITLE
Fixes POST on pictures route

### DIFF
--- a/routes/pictures.js
+++ b/routes/pictures.js
@@ -79,12 +79,15 @@ router.post("/pictures/:user_id", (req, res) => {
       searchForURL
         .then(result => {
           if (result.length > 0) {
-            pictureController.addToFavorites(user_id, result[0].picture_id);
-            return res.status(200).json(result);
+            pictureController.addToFavorites(user_id, result[0].picture_id).then(() => {
+              return res.status(200).json(result);
+            });
           } else {
             addToPictures
               .then(result => {
-                return res.status(200).json(result);
+                pictureController.addToFavorites(user_id, result[0].picture_id).then(() => {
+                  return res.status(200).json(result);
+                });
               })
               .catch(err => {
                 console.log("ERROR:", err);
@@ -107,9 +110,7 @@ router.delete("/pictures/:user_id/:picture_id", (req, res) => {
   let user_id = req.params.user_id;
   let picture_id = req.params.picture_id;
   let checkUserForPicture = pictureController.checkIfUserHasFavorite(user_id);
-  let pathPictureToDelete = pictureController.getPicturesByPictureId(
-    picture_id
-  );
+  let pathPictureToDelete = pictureController.getPicturesByPictureId(picture_id);
   let pictureToDelete;
   let deletePictureFromFavorites = pictureController.deletePictureFromFavorites(
     user_id,


### PR DESCRIPTION
Two minor tweaks to the logic:
1) Made sure reference to picture was added to favorites after picture data was added to pictures
2) pictureController.addToFavorites() method returns a promise, so sending 200 status code and json response was moved inside a .then() appended to the method--instead of on a separate line (as was the case before).